### PR TITLE
docs: Fix spelling of 'Pātimokkha' in MD file

### DIFF
--- a/pali-class/patimokkha-class.md
+++ b/pali-class/patimokkha-class.md
@@ -1,4 +1,4 @@
-# **Pātikokkha Word By Word class at SBS**
+# **Pātimokkha Word By Word class at SBS**
 
 **UNDER DEVELOPMENT**
 


### PR DESCRIPTION
Corrects a single-letter typo in the document. Changed 'Pātikokkha' to 'Pātimokkha'.